### PR TITLE
Added RobotConfig class

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -6,14 +6,13 @@ package frc.robot;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-// START: Setup AdvantageKit
+import frc.robot.config.RobotConfig;
 import org.littletonrobotics.junction.LoggedRobot;
 import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.networktables.NT4Publisher;
 import org.littletonrobotics.junction.wpilog.WPILOGWriter;
 import org.littletonrobotics.urcl.URCL;
 
-// END: Setup AdvantageKit
 public class Robot extends LoggedRobot {
   private Command m_autonomousCommand;
 
@@ -126,7 +125,7 @@ public class Robot extends LoggedRobot {
   @Override
   public void testPeriodic() {
     // Allow moving robot on the sim field when in test mode
-    m_robotContainer.drive.setPoseToMatchField();
+    RobotConfig.drive.setPoseToMatchField();
   }
 
   @Override

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -23,15 +23,11 @@ import frc.robot.config.RobotConfig;
 import frc.robot.config.RobotConfigInferno;
 import frc.robot.config.RobotConfigPhoenix;
 import frc.robot.config.RobotConfigSherman;
-import frc.robot.subsystems.arm.ArmIOSparkMax;
-import frc.robot.subsystems.arm.ArmIOStub;
-import frc.robot.subsystems.arm.ArmSubsystem;
 import org.littletonrobotics.junction.networktables.LoggedDashboardNumber;
 
 public class RobotContainer {
   public final CommandXboxController controller;
   public final RobotConfig robotConfig;
-  public final ArmSubsystem arm;
   private SendableChooser<Command> autoChooser = null;
   private static final String robotNameKey = "Robot Name";
 
@@ -40,10 +36,7 @@ public class RobotContainer {
 
   public RobotContainer() {
     String robotName = "UNKNOWN";
-
     controller = new CommandXboxController(0);
-
-    boolean hasArm = false;
 
     Preferences.initString(robotNameKey, robotName);
     robotName = Preferences.getString(robotNameKey, robotName);
@@ -64,12 +57,6 @@ public class RobotContainer {
         robotConfig = new RobotConfigInferno();
     }
 
-    if (hasArm) {
-      arm = new ArmSubsystem(new ArmIOSparkMax());
-    } else {
-      arm = new ArmSubsystem(new ArmIOStub());
-    }
-
     configureBindings();
     // ArmSysIdBindings();
     // shooterSysIdBindings();
@@ -77,10 +64,10 @@ public class RobotContainer {
   }
 
   private void ArmSysIdBindings() {
-    controller.a().whileTrue(arm.sysIdQuasistatic(SysIdRoutine.Direction.kForward));
-    controller.b().whileTrue(arm.sysIdQuasistatic(SysIdRoutine.Direction.kReverse));
-    controller.x().whileTrue(arm.sysIdDynamic(SysIdRoutine.Direction.kForward));
-    controller.y().whileTrue(arm.sysIdDynamic(SysIdRoutine.Direction.kReverse));
+    controller.a().whileTrue(RobotConfig.arm.sysIdQuasistatic(SysIdRoutine.Direction.kForward));
+    controller.b().whileTrue(RobotConfig.arm.sysIdQuasistatic(SysIdRoutine.Direction.kReverse));
+    controller.x().whileTrue(RobotConfig.arm.sysIdDynamic(SysIdRoutine.Direction.kForward));
+    controller.y().whileTrue(RobotConfig.arm.sysIdDynamic(SysIdRoutine.Direction.kReverse));
   }
 
   private void shooterSysIdBindings() {
@@ -135,14 +122,14 @@ public class RobotContainer {
     // run arm at 4 volts
     controller
         .y()
-        .whileTrue(Commands.startEnd(() -> arm.runVoltage(4), () -> arm.runVoltage(0), arm));
+        .whileTrue(Commands.startEnd(() -> RobotConfig.arm.runVoltage(4), () -> RobotConfig.arm.runVoltage(0), arm));
     // () -> arm.runVoltage(ArmVoltsEntry.getDouble(0.0)), () -> arm.runVoltage(0), arm));
     controller
         .x()
-        .whileTrue(Commands.startEnd(() -> arm.runVoltage(-4), () -> arm.runVoltage(0), arm));
+        .whileTrue(Commands.startEnd(() -> RobotConfig.arm.runVoltage(-4), () -> RobotConfig.arm.runVoltage(0), arm));
     */
 
-    controller.b().whileTrue(new ArmToPositionDebug(arm));
+    controller.b().whileTrue(new ArmToPositionDebug(RobotConfig.arm));
   }
 
   public Command getAutonomousCommand() {
@@ -156,6 +143,8 @@ public class RobotContainer {
   public void commandsToShuffleboard() {
     // SmartDashboard.putData(new ArmToPosition(arm));
     ShuffleboardTab armTab = Shuffleboard.getTab("Arm");
-    armTab.add("armToPosition", new ArmToPositionDebug(arm)).withWidget(BuiltInWidgets.kCommand);
+    armTab
+        .add("armToPosition", new ArmToPositionDebug(RobotConfig.arm))
+        .withWidget(BuiltInWidgets.kCommand);
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,12 +4,10 @@
 
 package frc.robot;
 
-import com.pathplanner.lib.auto.AutoBuilder;
 // import com.pathplanner.lib.commands.PathPlannerAuto;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.Preferences;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
@@ -18,110 +16,43 @@ import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.commands.IntakeBaseCommand;
 import frc.robot.commands.ShooterEnable;
 import frc.robot.commands.drive.DriveCommand;
-import frc.robot.subsystems.drive.DriveBase;
-import frc.robot.subsystems.drive.DriveSwerveYAGSL;
-import frc.robot.subsystems.drive.DriveTrain;
-import frc.robot.subsystems.intake.IntakeBase;
-import frc.robot.subsystems.intake.IntakeIOSim;
-import frc.robot.subsystems.intake.IntakeIOTalonSRX;
-import frc.robot.subsystems.shooter.ShooterIOSim;
-import frc.robot.subsystems.shooter.ShooterIOSparkMax;
-import frc.robot.subsystems.shooter.ShooterSubsystem;
+import frc.robot.config.RobotConfig;
+import frc.robot.config.RobotConfigInferno;
+import frc.robot.config.RobotConfigPhoenix;
+import frc.robot.config.RobotConfigSherman;
 import org.littletonrobotics.junction.networktables.LoggedDashboardNumber;
 
 public class RobotContainer {
   public final CommandXboxController controller;
-  public final ShooterSubsystem shooter;
-  public final IntakeBase intake;
-  public final DriveBase drive;
+  public final RobotConfig robotConfig;
   private SendableChooser<Command> autoChooser = null;
   private static final String robotNameKey = "Robot Name";
-
-  public enum RobotModel {
-    PHOENIX, // Practice Swerve Bot
-    SHERMAN, // Practice Tank Bot
-    INFERNO, // Competition Swerve Bot
-  }
-
-  public enum DriveType {
-    NONE,
-    SWERVE,
-    TANK
-  }
 
   private final LoggedDashboardNumber shooterSpeedInput =
       new LoggedDashboardNumber("Shooter Speed", 1000.0);
 
   public RobotContainer() {
-    RobotModel model = RobotModel.PHOENIX; // Default if "Robot Name" not found in preferences
     String robotName = "UNKNOWN";
 
     controller = new CommandXboxController(0);
-
-    boolean hasIntake = false;
-    boolean hasShooter = false;
-    DriveType driveType = DriveType.NONE;
-    String yagslConfigPath = null;
 
     Preferences.initString(robotNameKey, robotName);
     robotName = Preferences.getString(robotNameKey, robotName);
     System.out.println("Loading Settings for Robot Name = " + robotName);
     switch (robotName) {
       case "PHOENIX":
-        model = RobotModel.PHOENIX;
+        robotConfig = new RobotConfigPhoenix();
         break;
       case "SHERMAN":
-        model = RobotModel.SHERMAN;
+        robotConfig = new RobotConfigSherman();
         break;
       case "INFERNO":
-        model = RobotModel.INFERNO;
+        robotConfig = new RobotConfigInferno();
         break;
       case "UNKNOWN":
       default:
-    }
-
-    switch (model) {
-      case PHOENIX:
-        driveType = DriveType.SWERVE;
-        yagslConfigPath = "yagsl/phoenix";
-        break;
-      case SHERMAN:
-        driveType = DriveType.TANK;
-        hasIntake = true;
-        hasShooter = true;
-        break;
-      case INFERNO:
-        driveType = DriveType.SWERVE;
-        yagslConfigPath = "yagsl/inferno";
-      default:
-    }
-
-    if (hasShooter) {
-      shooter = new ShooterSubsystem(new ShooterIOSparkMax(2), new ShooterIOSparkMax(1));
-    } else {
-      shooter =
-          new ShooterSubsystem(
-              new ShooterIOSim(ShooterIOSim.ShooterId.SHOOTER_TOP),
-              new ShooterIOSim(ShooterIOSim.ShooterId.SHOOTER_BOTTOM));
-    }
-
-    if (hasIntake) {
-      intake = new IntakeBase(new IntakeIOTalonSRX());
-    } else {
-      intake = new IntakeBase(new IntakeIOSim());
-    }
-
-    switch (driveType) {
-      case SWERVE:
-        drive = new DriveSwerveYAGSL(yagslConfigPath);
-        autoChooser = AutoBuilder.buildAutoChooser("Mobility Auto");
-        SmartDashboard.putData("Auto Chooser", autoChooser);
-        break;
-      case TANK:
-        drive = new DriveTrain();
-        break;
-      default:
-        drive = new DriveBase();
+        /* If running simulation, put the robot config you want here */
+        robotConfig = new RobotConfigInferno();
     }
 
     configureBindings();
@@ -130,38 +61,38 @@ public class RobotContainer {
   }
 
   private void shooterSysIdBindings() {
-    controller.a().whileTrue(shooter.sysIdQuasistatic(SysIdRoutine.Direction.kForward));
-    controller.b().whileTrue(shooter.sysIdQuasistatic(SysIdRoutine.Direction.kReverse));
-    controller.x().whileTrue(shooter.sysIdDynamic(SysIdRoutine.Direction.kForward));
-    controller.y().whileTrue(shooter.sysIdDynamic(SysIdRoutine.Direction.kReverse));
+    controller.a().whileTrue(RobotConfig.shooter.sysIdQuasistatic(SysIdRoutine.Direction.kForward));
+    controller.b().whileTrue(RobotConfig.shooter.sysIdQuasistatic(SysIdRoutine.Direction.kReverse));
+    controller.x().whileTrue(RobotConfig.shooter.sysIdDynamic(SysIdRoutine.Direction.kForward));
+    controller.y().whileTrue(RobotConfig.shooter.sysIdDynamic(SysIdRoutine.Direction.kReverse));
   }
 
   private void driveSysIdBindings() {
-    controller.a().whileTrue(drive.sysIdDriveMotorCommand());
-    controller.b().whileTrue(drive.sysIdAngleMotorCommand());
+    controller.a().whileTrue(RobotConfig.drive.sysIdDriveMotorCommand());
+    controller.b().whileTrue(RobotConfig.drive.sysIdAngleMotorCommand());
   }
 
   private void configureBindings() {
     // shooter.setDefaultCommand(new InstantCommand(() -> shooter.disable(), shooter));
-    controller.rightTrigger().whileTrue(new ShooterEnable(shooter));
+    controller.rightTrigger().whileTrue(new ShooterEnable(RobotConfig.shooter));
 
     controller
         .a()
         .whileTrue(
             Commands.startEnd(
-                () -> shooter.runVelocity(shooterSpeedInput.get()),
-                () -> shooter.runVelocity(0),
-                shooter));
+                () -> RobotConfig.shooter.runVelocity(shooterSpeedInput.get()),
+                () -> RobotConfig.shooter.runVelocity(0),
+                RobotConfig.shooter));
 
-    intake.setDefaultCommand(
+    RobotConfig.intake.setDefaultCommand(
         new IntakeBaseCommand(
-            intake,
+            RobotConfig.intake,
             () -> controller.rightBumper().getAsBoolean(),
             () -> controller.leftBumper().getAsBoolean()));
 
-    drive.setDefaultCommand(
+    RobotConfig.drive.setDefaultCommand(
         new DriveCommand(
-            drive,
+            RobotConfig.drive,
             () -> MathUtil.applyDeadband(-controller.getLeftY(), 0.05),
             () -> MathUtil.applyDeadband(-controller.getLeftX(), 0.05),
             () -> MathUtil.applyDeadband(-controller.getRightX(), 0.05)));
@@ -170,9 +101,12 @@ public class RobotContainer {
     controller
         .start()
         .onTrue(
-            new InstantCommand(() -> drive.setFieldOrientedDrive(!drive.isFieldOrientedDrive())));
+            new InstantCommand(
+                () ->
+                    RobotConfig.drive.setFieldOrientedDrive(
+                        !RobotConfig.drive.isFieldOrientedDrive())));
 
-    controller.back().onTrue(new InstantCommand(() -> drive.resetOdometry()));
+    controller.back().onTrue(new InstantCommand(() -> RobotConfig.drive.resetOdometry()));
   }
 
   public Command getAutonomousCommand() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -10,6 +10,7 @@ import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
@@ -56,6 +57,8 @@ public class RobotContainer {
         /* If running simulation, put the robot config you want here */
         robotConfig = new RobotConfigInferno();
     }
+
+    SmartDashboard.putData("Auto Chooser", RobotConfig.autoChooser);
 
     configureBindings();
     // ArmSysIdBindings();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -54,6 +54,7 @@ public class RobotContainer {
       default:
         /* If running simulation, put the robot config you want here */
         robotConfig = new RobotConfigInferno();
+        // robotConfig = new RobotConfigSherman();
     }
 
     SmartDashboard.putData("Auto Chooser", RobotConfig.autoChooser);
@@ -134,11 +135,7 @@ public class RobotContainer {
   }
 
   public Command getAutonomousCommand() {
-    if (RobotConfig.autoChooser != null) {
-      return RobotConfig.autoChooser.getSelected();
-    } else {
-      return null;
-    }
+    return RobotConfig.autoChooser.getSelected();
   }
 
   public void commandsToShuffleboard() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -9,7 +9,6 @@ import edu.wpi.first.wpilibj.Preferences;
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
-import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -29,7 +28,6 @@ import org.littletonrobotics.junction.networktables.LoggedDashboardNumber;
 public class RobotContainer {
   public final CommandXboxController controller;
   public final RobotConfig robotConfig;
-  private SendableChooser<Command> autoChooser = null;
   private static final String robotNameKey = "Robot Name";
 
   private final LoggedDashboardNumber shooterSpeedInput =
@@ -136,8 +134,8 @@ public class RobotContainer {
   }
 
   public Command getAutonomousCommand() {
-    if (autoChooser != null) {
-      return autoChooser.getSelected();
+    if (RobotConfig.autoChooser != null) {
+      return RobotConfig.autoChooser.getSelected();
     } else {
       return null;
     }

--- a/src/main/java/frc/robot/config/RobotConfig.java
+++ b/src/main/java/frc/robot/config/RobotConfig.java
@@ -1,5 +1,7 @@
 package frc.robot.config;
 
+import frc.robot.subsystems.arm.ArmIOStub;
+import frc.robot.subsystems.arm.ArmSubsystem;
 import frc.robot.subsystems.drive.DriveBase;
 import frc.robot.subsystems.intake.IntakeBase;
 import frc.robot.subsystems.intake.IntakeIOSim;
@@ -11,12 +13,23 @@ public class RobotConfig {
   public static DriveBase drive;
   public static IntakeBase intake;
   public static ShooterSubsystem shooter;
+  public static ArmSubsystem arm;
 
   public static class DriveConstants {
     public static double maxVelocityMetersPerSec = 4.5;
   }
 
-  public static class ArmConstants {}
+  public static class ArmConstants {
+    public static double absolutePositionOffset = 0; /* 0-1 */
+
+    public static double pidKp = 0.1;
+    public static double pidKi = 0.0;
+    public static double pidKd = 0.0;
+    public static double ffKs = 0.0;
+    public static double ffKg = 0.1;
+    public static double ffKv = 0.0;
+    public static double ffKa = 0.0;
+  }
 
   public static class ShooterConstants {
     /* Feedforward */
@@ -43,6 +56,10 @@ public class RobotConfig {
   }
 
   public RobotConfig(boolean stubDrive, boolean stubShooter, boolean stubIntake) {
+    this(stubDrive, stubShooter, stubIntake, true);
+  }
+
+  public RobotConfig(boolean stubDrive, boolean stubShooter, boolean stubIntake, boolean stubArm) {
     if (stubDrive) {
       drive = new DriveBase();
     }
@@ -56,6 +73,10 @@ public class RobotConfig {
 
     if (stubIntake) {
       intake = new IntakeBase(new IntakeIOSim());
+    }
+
+    if (stubArm) {
+      arm = new ArmSubsystem(new ArmIOStub());
     }
   }
 }

--- a/src/main/java/frc/robot/config/RobotConfig.java
+++ b/src/main/java/frc/robot/config/RobotConfig.java
@@ -1,0 +1,61 @@
+package frc.robot.config;
+
+import frc.robot.subsystems.drive.DriveBase;
+import frc.robot.subsystems.intake.IntakeBase;
+import frc.robot.subsystems.intake.IntakeIOSim;
+import frc.robot.subsystems.shooter.ShooterIOSim;
+import frc.robot.subsystems.shooter.ShooterSubsystem;
+
+/* Put all constants here with reasonable defaults */
+public class RobotConfig {
+  public static DriveBase drive;
+  public static IntakeBase intake;
+  public static ShooterSubsystem shooter;
+
+  public static class DriveConstants {
+    public static double maxVelocityMetersPerSec = 4.5;
+  }
+
+  public static class ArmConstants {}
+
+  public static class ShooterConstants {
+    /* Feedforward */
+    public static double ffKs = 0.1;
+    public static double ffKv = 0.0;
+    public static double ffKa = 0.0;
+    public static double ffKsBottom = 0.1;
+    public static double ffKvBottom = 0.0;
+    public static double ffKaBottom = 0.0;
+
+    /* PID */
+    public static double pidKp = 0.1;
+    public static double pidKi = 0.0;
+    public static double pidKd = 0.0;
+    public static double pidKpBottom = 0.1;
+    public static double pidKiBottom = 0.0;
+    public static double pidKdBottom = 0.0;
+  }
+
+  public static class IntakeConstants {}
+
+  public RobotConfig() {
+    this(true, true, true);
+  }
+
+  public RobotConfig(boolean stubDrive, boolean stubShooter, boolean stubIntake) {
+    if (stubDrive) {
+      drive = new DriveBase();
+    }
+
+    if (stubShooter) {
+      shooter =
+          new ShooterSubsystem(
+              new ShooterIOSim(ShooterIOSim.ShooterId.SHOOTER_TOP),
+              new ShooterIOSim(ShooterIOSim.ShooterId.SHOOTER_BOTTOM));
+    }
+
+    if (stubIntake) {
+      intake = new IntakeBase(new IntakeIOSim());
+    }
+  }
+}

--- a/src/main/java/frc/robot/config/RobotConfig.java
+++ b/src/main/java/frc/robot/config/RobotConfig.java
@@ -1,5 +1,8 @@
 package frc.robot.config;
 
+import com.pathplanner.lib.auto.AutoBuilder;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.arm.ArmIOStub;
 import frc.robot.subsystems.arm.ArmSubsystem;
 import frc.robot.subsystems.drive.DriveBase;
@@ -14,6 +17,7 @@ public class RobotConfig {
   public static IntakeBase intake;
   public static ShooterSubsystem shooter;
   public static ArmSubsystem arm;
+  public static SendableChooser<Command> autoChooser;
 
   public static class DriveConstants {
     public static double maxVelocityMetersPerSec = 4.5;
@@ -78,5 +82,7 @@ public class RobotConfig {
     if (stubArm) {
       arm = new ArmSubsystem(new ArmIOStub());
     }
+
+    autoChooser = AutoBuilder.buildAutoChooser("Mobility Auto");
   }
 }

--- a/src/main/java/frc/robot/config/RobotConfig.java
+++ b/src/main/java/frc/robot/config/RobotConfig.java
@@ -1,8 +1,8 @@
 package frc.robot.config;
 
-import com.pathplanner.lib.auto.AutoBuilder;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import frc.robot.subsystems.arm.ArmIOStub;
 import frc.robot.subsystems.arm.ArmSubsystem;
 import frc.robot.subsystems.drive.DriveBase;
@@ -60,10 +60,15 @@ public class RobotConfig {
   }
 
   public RobotConfig(boolean stubDrive, boolean stubShooter, boolean stubIntake) {
-    this(stubDrive, stubShooter, stubIntake, true);
+    this(stubDrive, stubShooter, stubIntake, true, true);
   }
 
-  public RobotConfig(boolean stubDrive, boolean stubShooter, boolean stubIntake, boolean stubArm) {
+  public RobotConfig(
+      boolean stubDrive,
+      boolean stubShooter,
+      boolean stubIntake,
+      boolean stubArm,
+      boolean stubAuto) {
     if (stubDrive) {
       drive = new DriveBase();
     }
@@ -83,6 +88,9 @@ public class RobotConfig {
       arm = new ArmSubsystem(new ArmIOStub());
     }
 
-    autoChooser = AutoBuilder.buildAutoChooser("Mobility Auto");
+    if (stubAuto) {
+      autoChooser = new SendableChooser<>();
+      autoChooser.setDefaultOption("No Auto Routines Specified", Commands.none());
+    }
   }
 }

--- a/src/main/java/frc/robot/config/RobotConfigInferno.java
+++ b/src/main/java/frc/robot/config/RobotConfigInferno.java
@@ -1,14 +1,16 @@
 package frc.robot.config;
 
+import com.pathplanner.lib.auto.AutoBuilder;
 import frc.robot.subsystems.drive.DriveSwerveYAGSL;
 
 /* Override Inferno specific constants here */
 public class RobotConfigInferno extends RobotConfig {
   public RobotConfigInferno() {
-    super(false, true, true);
+    super(false, true, true, true, false);
 
     // Inferno has a Swerve drive train
     // TODO: set DriveConstants.maxVelocityMetersPerSec
     drive = new DriveSwerveYAGSL("yagsl/inferno");
+    autoChooser = AutoBuilder.buildAutoChooser("Mobility Auto");
   }
 }

--- a/src/main/java/frc/robot/config/RobotConfigInferno.java
+++ b/src/main/java/frc/robot/config/RobotConfigInferno.java
@@ -1,0 +1,14 @@
+package frc.robot.config;
+
+import frc.robot.subsystems.drive.DriveSwerveYAGSL;
+
+/* Override Inferno specific constants here */
+public class RobotConfigInferno extends RobotConfig {
+  public RobotConfigInferno() {
+    super(false, true, true);
+
+    // Inferno has a Swerve drive train
+    // TODO: set DriveConstants.maxVelocityMetersPerSec
+    drive = new DriveSwerveYAGSL("yagsl/inferno");
+  }
+}

--- a/src/main/java/frc/robot/config/RobotConfigPhoenix.java
+++ b/src/main/java/frc/robot/config/RobotConfigPhoenix.java
@@ -1,0 +1,14 @@
+package frc.robot.config;
+
+import frc.robot.subsystems.drive.DriveSwerveYAGSL;
+
+/* Override Phoenix specific constants here */
+public class RobotConfigPhoenix extends RobotConfig {
+  public RobotConfigPhoenix() {
+    super(false, true, true);
+
+    // Phoenix has a Swerve drive train
+    // TODO: set DriveConstants.maxVelocityMetersPerSec
+    drive = new DriveSwerveYAGSL("yagsl/phoenix");
+  }
+}

--- a/src/main/java/frc/robot/config/RobotConfigPhoenix.java
+++ b/src/main/java/frc/robot/config/RobotConfigPhoenix.java
@@ -1,14 +1,16 @@
 package frc.robot.config;
 
+import com.pathplanner.lib.auto.AutoBuilder;
 import frc.robot.subsystems.drive.DriveSwerveYAGSL;
 
 /* Override Phoenix specific constants here */
 public class RobotConfigPhoenix extends RobotConfig {
   public RobotConfigPhoenix() {
-    super(false, true, true);
+    super(false, true, true, true, false);
 
     // Phoenix has a Swerve drive train
     // TODO: set DriveConstants.maxVelocityMetersPerSec
     drive = new DriveSwerveYAGSL("yagsl/phoenix");
+    autoChooser = AutoBuilder.buildAutoChooser("Mobility Auto");
   }
 }

--- a/src/main/java/frc/robot/config/RobotConfigSherman.java
+++ b/src/main/java/frc/robot/config/RobotConfigSherman.java
@@ -1,5 +1,7 @@
 package frc.robot.config;
 
+import frc.robot.subsystems.arm.ArmIOSparkMax;
+import frc.robot.subsystems.arm.ArmSubsystem;
 import frc.robot.subsystems.drive.DriveTrain;
 import frc.robot.subsystems.intake.IntakeBase;
 import frc.robot.subsystems.intake.IntakeIOTalonSRX;
@@ -9,7 +11,7 @@ import frc.robot.subsystems.shooter.ShooterSubsystem;
 /* Override Sherman specific constants here */
 public class RobotConfigSherman extends RobotConfig {
   public RobotConfigSherman() {
-    super(false, false, false);
+    super(false, false, false, false);
 
     // Sherman has a tank drive train
     // TODO: set DriveConstants.maxVelocityMetersPerSec
@@ -36,5 +38,16 @@ public class RobotConfigSherman extends RobotConfig {
     ShooterConstants.pidKdBottom = 0.0;
 
     shooter = new ShooterSubsystem(new ShooterIOSparkMax(2), new ShooterIOSparkMax(1));
+
+    ArmConstants.absolutePositionOffset = 0.4154156603853915; // This is place holder
+
+    ArmConstants.pidKp = 0.1;
+    ArmConstants.pidKi = 0.0;
+    ArmConstants.pidKd = 0.0;
+    ArmConstants.ffKs = 0.0;
+    ArmConstants.ffKg = 0.72;
+    ArmConstants.ffKv = 6.18;
+    ArmConstants.ffKa = 0.04;
+    arm = new ArmSubsystem(new ArmIOSparkMax());
   }
 }

--- a/src/main/java/frc/robot/config/RobotConfigSherman.java
+++ b/src/main/java/frc/robot/config/RobotConfigSherman.java
@@ -1,0 +1,40 @@
+package frc.robot.config;
+
+import frc.robot.subsystems.drive.DriveTrain;
+import frc.robot.subsystems.intake.IntakeBase;
+import frc.robot.subsystems.intake.IntakeIOTalonSRX;
+import frc.robot.subsystems.shooter.ShooterIOSparkMax;
+import frc.robot.subsystems.shooter.ShooterSubsystem;
+
+/* Override Sherman specific constants here */
+public class RobotConfigSherman extends RobotConfig {
+  public RobotConfigSherman() {
+    super(false, false, false);
+
+    // Sherman has a tank drive train
+    // TODO: set DriveConstants.maxVelocityMetersPerSec
+    drive = new DriveTrain();
+
+    // Sherman has a TalonSRX based intake
+    intake = new IntakeBase(new IntakeIOTalonSRX());
+
+    // Sherman has a dual SparkMax based shooter
+
+    // Values from Carter's Shooter SysId Run on Sherman 2024-02-07
+    ShooterConstants.ffKs = 0.08134;
+    ShooterConstants.ffKv = 0.019999;
+    ShooterConstants.ffKa = 0.0054252;
+    ShooterConstants.ffKsBottom = 0.058262;
+    ShooterConstants.ffKvBottom = 0.019495;
+    ShooterConstants.ffKaBottom = 0.0048198;
+
+    ShooterConstants.pidKp = 0.0010514;
+    ShooterConstants.pidKi = 0.0;
+    ShooterConstants.pidKd = 0.0;
+    ShooterConstants.pidKpBottom = 0.0001581;
+    ShooterConstants.pidKiBottom = 0.0;
+    ShooterConstants.pidKdBottom = 0.0;
+
+    shooter = new ShooterSubsystem(new ShooterIOSparkMax(2), new ShooterIOSparkMax(1));
+  }
+}

--- a/src/main/java/frc/robot/config/RobotConfigSherman.java
+++ b/src/main/java/frc/robot/config/RobotConfigSherman.java
@@ -11,7 +11,7 @@ import frc.robot.subsystems.shooter.ShooterSubsystem;
 /* Override Sherman specific constants here */
 public class RobotConfigSherman extends RobotConfig {
   public RobotConfigSherman() {
-    super(false, false, false, false);
+    super(false, false, false, false, true);
 
     // Sherman has a tank drive train
     // TODO: set DriveConstants.maxVelocityMetersPerSec

--- a/src/main/java/frc/robot/subsystems/arm/ArmIOSparkMax.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmIOSparkMax.java
@@ -10,6 +10,7 @@ import com.revrobotics.SparkPIDController.ArbFFUnits;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants;
+import frc.robot.config.RobotConfig.ArmConstants;
 
 public class ArmIOSparkMax implements ArmIO {
   // Leader
@@ -32,7 +33,7 @@ public class ArmIOSparkMax implements ArmIO {
     // This will need to be set from a constant once we have the arm assembled and can measure the
     // offset.  Once the arm is done this value won't change.
     //
-    absoluteEncoder.setPositionOffset(0.4154156603853915); // This is place holder
+    absoluteEncoder.setPositionOffset(ArmConstants.absolutePositionOffset); // This is place holder
 
     absoluteEncoder.setDutyCycleRange(1.0 / 1024.0, 1023.0 / 1024.0);
 

--- a/src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java
@@ -17,6 +17,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.Constants;
+import frc.robot.config.RobotConfig.ArmConstants;
 import frc.robot.util.LoggedTunableNumber;
 import java.util.Map;
 import org.littletonrobotics.junction.AutoLogOutput;
@@ -62,11 +63,11 @@ public class ArmSubsystem extends SubsystemBase implements Arm {
   public ArmSubsystem(ArmIO io) {
     this.io = io;
 
-    armKp.initDefault(.1);
-    armKd.initDefault(0.0);
-    armKg.initDefault(.72);
-    armKv.initDefault(6.18);
-    armKa.initDefault(.04);
+    armKp.initDefault(ArmConstants.pidKp);
+    armKd.initDefault(ArmConstants.pidKd);
+    armKg.initDefault(ArmConstants.ffKg);
+    armKv.initDefault(ArmConstants.ffKv);
+    armKa.initDefault(ArmConstants.ffKa);
 
     kG = armKg.get();
     kV = armKv.get();

--- a/src/main/java/frc/robot/subsystems/drive/DriveSwerveYAGSL.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSwerveYAGSL.java
@@ -10,6 +10,7 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Config;
+import frc.robot.config.RobotConfig.DriveConstants;
 import java.io.File;
 import org.littletonrobotics.junction.AutoLogOutput;
 import swervelib.SwerveDrive;
@@ -17,20 +18,17 @@ import swervelib.SwerveDriveTest;
 import swervelib.parser.SwerveParser;
 
 public class DriveSwerveYAGSL extends DriveBase {
-  private final double maximumSpeed = 4.5; // meters/sec
   private final File swerveJsonDirectory;
   private SwerveDrive swerveDrive;
   @AutoLogOutput private boolean fieldOrientedDrive = false;
-
-  public DriveSwerveYAGSL() {
-    this("swervePracticeBot");
-  }
 
   public DriveSwerveYAGSL(String configPath) {
     swerveJsonDirectory = new File(Filesystem.getDeployDirectory(), configPath);
 
     try {
-      swerveDrive = new SwerveParser(swerveJsonDirectory).createSwerveDrive(maximumSpeed);
+      swerveDrive =
+          new SwerveParser(swerveJsonDirectory)
+              .createSwerveDrive(DriveConstants.maxVelocityMetersPerSec);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
@@ -8,6 +8,7 @@ import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
+import frc.robot.config.RobotConfig.ShooterConstants;
 import org.littletonrobotics.junction.AutoLogOutput;
 import org.littletonrobotics.junction.Logger;
 
@@ -27,30 +28,26 @@ public class ShooterSubsystem extends SubsystemBase implements Shooter {
   boolean useSoftwarePid = false;
   boolean softwarePidEnabled = false;
 
-  // Values from Carter's Shooter SysId Run on Sherman 2024-02-07
-  double ffKs = 0.08134;
-  double ffKv = 0.019999;
-  double ffKa = 0.0054252;
-  double ffKsBottom = 0.058262;
-  double ffKvBottom = 0.019495;
-  double ffKaBottom = 0.0048198;
-
-  double pidKp = 0.0010514;
-  double pidKi = 0.0;
-  double pidKd = 0.0;
-  double pidKpBottom = 0.0001581;
-  double pidKiBottom = 0.0;
-  double pidKdBottom = 0.0;
-
   public ShooterSubsystem(ShooterIO io) {
     this.io = io;
     // TODO: These are sample values.  Need to run sysid on shooter and get real values.
     useSoftwarePid = !io.supportsHardwarePid();
     if (useSoftwarePid) {
-      feedforward = new SimpleMotorFeedforward(ffKs, ffKv, ffKa);
-      feedforwardBottom = new SimpleMotorFeedforward(ffKsBottom, ffKvBottom, ffKaBottom);
-      pid = new PIDController(pidKp, pidKi, pidKd);
-      pidBottom = new PIDController(pidKpBottom, pidKiBottom, pidKdBottom);
+      feedforward =
+          new SimpleMotorFeedforward(
+              ShooterConstants.ffKs, ShooterConstants.ffKv, ShooterConstants.ffKa);
+      feedforwardBottom =
+          new SimpleMotorFeedforward(
+              ShooterConstants.ffKsBottom,
+              ShooterConstants.ffKvBottom,
+              ShooterConstants.ffKaBottom);
+      pid =
+          new PIDController(ShooterConstants.pidKp, ShooterConstants.pidKi, ShooterConstants.pidKd);
+      pidBottom =
+          new PIDController(
+              ShooterConstants.pidKpBottom,
+              ShooterConstants.pidKiBottom,
+              ShooterConstants.pidKdBottom);
     } else {
       feedforward = null;
       feedforwardBottom = null;


### PR DESCRIPTION
The RobotConfig class should allow us to more easily support the 3 different robots this year using a single code base.

RobotConfig is the default base class, and each robot extends this class (e.g. RobotConfig_Phoenix_, RobotConfig_Sherman_, etc) and sets the robot specific parameters including things like CAN IDs, PID values etc.

The changes in this commit should allow us to more easily support 2 robots, each with their own physical characteristics.