### PR TITLE
Inferno-DrivetrainBringUp

### DIFF
--- a/src/main/deploy/yagsl/inferno/modules/backleft.json
+++ b/src/main/deploy/yagsl/inferno/modules/backleft.json
@@ -3,7 +3,7 @@
     "front": -11.375,
     "left": 11.375
   },
-  "absoluteEncoderOffset": 79.541,
+  "absoluteEncoderOffset": 258.398,
   "drive": {
     "type": "sparkmax",
     "id": 12,
@@ -24,7 +24,7 @@
     "canbus": null
   },
   "inverted": {
-    "drive": false,
+    "drive": true,
     "angle": true
   },
   "absoluteEncoderInverted": false

--- a/src/main/deploy/yagsl/inferno/modules/backright.json
+++ b/src/main/deploy/yagsl/inferno/modules/backright.json
@@ -3,7 +3,7 @@
     "front": -11.375,
     "left": -11.375
   },
-  "absoluteEncoderOffset": 136.537,
+  "absoluteEncoderOffset": 132.539,
   "drive": {
     "type": "sparkmax",
     "id": 13,

--- a/src/main/deploy/yagsl/inferno/modules/frontleft.json
+++ b/src/main/deploy/yagsl/inferno/modules/frontleft.json
@@ -3,7 +3,7 @@
     "front": 11.375,
     "left": 11.375
   },
-  "absoluteEncoderOffset": 97.186,
+  "absoluteEncoderOffset": 274.658,
   "drive": {
     "type": "sparkmax",
     "id": 10,
@@ -24,7 +24,7 @@
     "canbus": null
   },
   "inverted": {
-    "drive": false,
+    "drive": true,
     "angle": true
   },
   "absoluteEncoderInverted": false

--- a/src/main/deploy/yagsl/inferno/modules/frontright.json
+++ b/src/main/deploy/yagsl/inferno/modules/frontright.json
@@ -3,7 +3,7 @@
     "front": 11.375,
     "left": -11.375
   },
-  "absoluteEncoderOffset": 150.602,
+  "absoluteEncoderOffset": 330.117,
   "drive": {
     "type": "sparkmax",
     "id": 11,
@@ -24,7 +24,7 @@
     "canbus": null
   },
   "inverted": {
-    "drive": false,
+    "drive": true,
     "angle": true
   },
   "absoluteEncoderInverted": false

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -137,8 +137,8 @@ public class RobotContainer {
         .withPosition(colIndex, rowIndex++)
         .withSize(2, 1);
 
-    // sysIdTestTab.add("Drive: Drive Motors", RobotConfig.drive.sysIdDriveMotorCommand());
-    // sysIdTestTab.add("Drive: Angle Motors", RobotConfig.drive.sysIdAngleMotorCommand());
+    sysIdTestTab.add("Drive: Drive Motors", RobotConfig.drive.sysIdDriveMotorCommand());
+    sysIdTestTab.add("Drive: Angle Motors", RobotConfig.drive.sysIdAngleMotorCommand());
   }
 
   private void configureBindings() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -137,8 +137,12 @@ public class RobotContainer {
         .withPosition(colIndex, rowIndex++)
         .withSize(2, 1);
 
-    sysIdTestTab.add("Drive: Drive Motors", RobotConfig.drive.sysIdDriveMotorCommand());
-    sysIdTestTab.add("Drive: Angle Motors", RobotConfig.drive.sysIdAngleMotorCommand());
+    /*
+    colIndex++;
+    rowIndex = 0;
+    sysIdTestTab.add("Drive: Drive Motors", RobotConfig.drive.sysIdDriveMotorCommand()).withPosition(colIndex, rowIndex++).withSize(2, 1);
+    sysIdTestTab.add("Drive: Angle Motors", RobotConfig.drive.sysIdAngleMotorCommand()).withPosition(colIndex, rowIndex++).withSize(2, 1);
+    */
   }
 
   private void configureBindings() {

--- a/src/main/java/frc/robot/config/RobotConfig.java
+++ b/src/main/java/frc/robot/config/RobotConfig.java
@@ -25,6 +25,10 @@ public class RobotConfig {
   public static class DriveConstants {
     public static double maxVelocityMetersPerSec = 4.5;
     public static double maxAngularVelocityRadiansSec = 2 * Math.PI;
+
+    public static double slewRateLimiterX = 3;
+    public static double slewRateLimiterY = 3;
+    public static double slewRateLimiterAngle = 3;
   }
 
   public static class ArmConstants {

--- a/src/main/java/frc/robot/config/RobotConfigInferno.java
+++ b/src/main/java/frc/robot/config/RobotConfigInferno.java
@@ -26,7 +26,7 @@ public class RobotConfigInferno extends RobotConfig {
     IntakeConstants.indexSpeedInVolts = 6.0;
     IntakeConstants.feedSpeedInVolts = 6.0;
 
-    intake = new IntakeSubsystem(new IntakeIOTalonSRX(3));
+    intake = new IntakeSubsystem(new IntakeIOTalonSRX(3, true));
 
     // Inferno has a single SparkMax based shooter
 

--- a/src/main/java/frc/robot/config/RobotConfigInferno.java
+++ b/src/main/java/frc/robot/config/RobotConfigInferno.java
@@ -63,7 +63,7 @@ public class RobotConfigInferno extends RobotConfig {
 
     ClimberConstants.minPositionInRadians = 0.01;
     ClimberConstants.maxPositionInRadians = 0.47;
-    ClimberConstants.defaultSpeedInVolts = 2.0;
+    ClimberConstants.defaultSpeedInVolts = 12.0;
     ClimberConstants.autoZeroVoltage = 2.0;
     ClimberConstants.autoZeroMaxCurrent = 16;
     ClimberConstants.autoZeroMinVelocity = 1.0;

--- a/src/main/java/frc/robot/subsystems/climber/ClimberIOSparkMax.java
+++ b/src/main/java/frc/robot/subsystems/climber/ClimberIOSparkMax.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.climber;
 
+import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
@@ -26,6 +27,7 @@ public class ClimberIOSparkMax implements ClimberIO {
 
     motor.enableVoltageCompensation(12.0);
     motor.setSmartCurrentLimit(30);
+    motor.setIdleMode(IdleMode.kBrake);
 
     motor.burnFlash();
   }

--- a/src/main/java/frc/robot/subsystems/climber/ClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/climber/ClimberSubsystem.java
@@ -81,9 +81,15 @@ public class ClimberSubsystem extends SubsystemBase implements Climber {
           }
         }
       } else {
-        return extend
-            ? (inputs.positionRadians >= ClimberConstants.maxPositionInRadians)
-            : (inputs.positionRadians <= ClimberConstants.minPositionInRadians);
+        boolean atLimit =
+            extend
+                ? (inputs.positionRadians >= ClimberConstants.maxPositionInRadians)
+                : (inputs.positionRadians <= ClimberConstants.minPositionInRadians);
+        ;
+        if (atLimit) {
+          runVoltage(0);
+        }
+        return atLimit;
       }
     }
 

--- a/src/main/java/frc/robot/subsystems/drive/DriveSwerveYAGSL.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSwerveYAGSL.java
@@ -19,7 +19,6 @@ import swervelib.SwerveDriveTest;
 import swervelib.parser.PIDFConfig;
 import swervelib.parser.SwerveParser;
 import swervelib.telemetry.SwerveDriveTelemetry;
-import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
 
 public class DriveSwerveYAGSL extends DriveBase {
   private final File swerveJsonDirectory;
@@ -29,7 +28,7 @@ public class DriveSwerveYAGSL extends DriveBase {
   public DriveSwerveYAGSL(String configPath) {
     swerveJsonDirectory = new File(Filesystem.getDeployDirectory(), configPath);
 
-    SwerveDriveTelemetry.verbosity = TelemetryVerbosity.HIGH;
+    // SwerveDriveTelemetry.verbosity = TelemetryVerbosity.HIGH;
     try {
       swerveDrive =
           new SwerveParser(swerveJsonDirectory)

--- a/src/main/java/frc/robot/subsystems/drive/DriveSwerveYAGSL.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSwerveYAGSL.java
@@ -4,6 +4,7 @@ import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.util.HolonomicPathFollowerConfig;
 import com.pathplanner.lib.util.PIDConstants;
 import com.pathplanner.lib.util.ReplanningConfig;
+import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.DriverStation;
@@ -33,6 +34,13 @@ public class DriveSwerveYAGSL extends DriveBase {
           new SwerveParser(swerveJsonDirectory)
               .createSwerveDrive(DriveConstants.maxVelocityMetersPerSec);
       swerveDrive.setCosineCompensator(!SwerveDriveTelemetry.isSimulation);
+
+      swerveDrive
+          .getSwerveController()
+          .addSlewRateLimiters(
+              new SlewRateLimiter(DriveConstants.slewRateLimiterX),
+              new SlewRateLimiter(DriveConstants.slewRateLimiterY),
+              new SlewRateLimiter(DriveConstants.slewRateLimiterAngle));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/frc/robot/subsystems/drive/DriveSwerveYAGSL.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSwerveYAGSL.java
@@ -41,6 +41,8 @@ public class DriveSwerveYAGSL extends DriveBase {
               new SlewRateLimiter(DriveConstants.slewRateLimiterX),
               new SlewRateLimiter(DriveConstants.slewRateLimiterY),
               new SlewRateLimiter(DriveConstants.slewRateLimiterAngle));
+
+      swerveDrive.setMotorIdleMode(true);              
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/frc/robot/subsystems/drive/DriveSwerveYAGSL.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSwerveYAGSL.java
@@ -19,6 +19,7 @@ import swervelib.SwerveDriveTest;
 import swervelib.parser.PIDFConfig;
 import swervelib.parser.SwerveParser;
 import swervelib.telemetry.SwerveDriveTelemetry;
+import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
 
 public class DriveSwerveYAGSL extends DriveBase {
   private final File swerveJsonDirectory;
@@ -28,7 +29,7 @@ public class DriveSwerveYAGSL extends DriveBase {
   public DriveSwerveYAGSL(String configPath) {
     swerveJsonDirectory = new File(Filesystem.getDeployDirectory(), configPath);
 
-    // SwerveDriveTelemetry.verbosity = TelemetryVerbosity.HIGH;
+    SwerveDriveTelemetry.verbosity = TelemetryVerbosity.HIGH;
     try {
       swerveDrive =
           new SwerveParser(swerveJsonDirectory)

--- a/src/main/java/frc/robot/subsystems/drive/DriveSwerveYAGSL.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSwerveYAGSL.java
@@ -42,7 +42,7 @@ public class DriveSwerveYAGSL extends DriveBase {
               new SlewRateLimiter(DriveConstants.slewRateLimiterY),
               new SlewRateLimiter(DriveConstants.slewRateLimiterAngle));
 
-      swerveDrive.setMotorIdleMode(true);              
+      swerveDrive.setMotorIdleMode(true);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOTalonSRX.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOTalonSRX.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems.intake;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.RobotController;
@@ -17,6 +18,7 @@ public class IntakeIOTalonSRX implements IntakeIO {
     leader = new TalonSRX(id);
     // leader motor is not inverted, and set follower motor to follow the leader
     leader.setInverted(inverted);
+    leader.setNeutralMode(NeutralMode.Brake);
   }
 
   public IntakeIOTalonSRX(int id) {

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOTalonSRX.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOTalonSRX.java
@@ -13,10 +13,14 @@ public class IntakeIOTalonSRX implements IntakeIO {
   DigitalInput limitSwitchIntake = new DigitalInput(1);
   DigitalInput limitSwitchShooter = new DigitalInput(2);
 
-  public IntakeIOTalonSRX(int id) {
+  public IntakeIOTalonSRX(int id, boolean inverted) {
     leader = new TalonSRX(id);
     // leader motor is not inverted, and set follower motor to follow the leader
-    leader.setInverted(false);
+    leader.setInverted(inverted);
+  }
+
+  public IntakeIOTalonSRX(int id) {
+    this(id, false);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIOSparkMax.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIOSparkMax.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.shooter;
 
+import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
@@ -33,6 +34,7 @@ public class ShooterIOSparkMax implements ShooterIO {
 
     flywheel.enableVoltageCompensation(12.0);
     flywheel.setSmartCurrentLimit(30);
+    flywheel.setIdleMode(IdleMode.kCoast);
 
     flywheel.burnFlash();
 


### PR DESCRIPTION
For Inferno:

1. Drivetrain
   1. Updated YAGSL module config (inversion and absolute encoder offset)
   2. Added slew rate limiter
   3. Set brake mode
2. Intake
   1. Inverted motor
   2. Set brake mode
4. Climber
   1. Set brake mode
   2. Fixed issue with stopping when at limit
5. Shooter
   1. Set coast mode
