### PR TITLE
Voltage comp

### DIFF
--- a/src/main/java/frc/robot/subsystems/arm/ArmIOSparkMax.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmIOSparkMax.java
@@ -52,7 +52,7 @@ public class ArmIOSparkMax implements ArmIO {
 
     motor.setInverted(inverted);
 
-    // motor.enableVoltageCompensation(12.0);
+    motor.enableVoltageCompensation(10.0);
     motor.setSmartCurrentLimit(40);
 
     // Initialize the relative encoder position based on absolute encoder position.  The abs and rel

--- a/src/main/java/frc/robot/subsystems/climber/ClimberIOSparkMax.java
+++ b/src/main/java/frc/robot/subsystems/climber/ClimberIOSparkMax.java
@@ -26,7 +26,7 @@ public class ClimberIOSparkMax implements ClimberIO {
 
     motor.setInverted(inverted);
 
-    motor.enableVoltageCompensation(12.0);
+    motor.enableVoltageCompensation(10.0);
     motor.setSmartCurrentLimit(30);
     motor.setIdleMode(IdleMode.kBrake);
 

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIOSparkMax.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIOSparkMax.java
@@ -35,7 +35,7 @@ public class ShooterIOSparkMax implements ShooterIO {
     encoder = flywheel.getEncoder();
     flywheel.setInverted(false);
 
-    flywheel.enableVoltageCompensation(12.0);
+    flywheel.enableVoltageCompensation(10.0);
     flywheel.setSmartCurrentLimit(30);
 
     // Set motor to brake mode so shooter stops spinning immediately


### PR DESCRIPTION
Did some research on voltage compensation.  I think it should be set to <12V.

- https://www.chiefdelphi.com/t/sparkmax-built-in-pid-velocity-controller-help/456544
- https://www.chiefdelphi.com/t/do-i-understand-voltage-compensation-correctly/456982
- https://www.chiefdelphi.com/t/voltage-compensation-vs-just-controlling-voltage/413761

Update shooter encoder filter settings based on 
- https://www.chiefdelphi.com/t/psa-default-neo-sparkmax-velocity-readings-are-still-bad-for-flywheels/454453/32
- https://www.chiefdelphi.com/t/what-is-the-best-performance-for-a-shooter/457903/25

Adjust some shooter PID settings.  It looked like they were hard coded in subsystem instead of using RobotConfig.ShooterConstants.  Also we should be using FF in the sparkmax PID controller, along with P.